### PR TITLE
Updated to work with watchOS

### DIFF
--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -86,11 +86,11 @@ import SwiftUI
 ///         } else if syncMonitor.notSyncing {
 ///             Image(systemName: "xmark.icloud")
 ///         } else {
-///             Image(systemName: .icloud).foregroundColor(.green)
+///             Image(systemName: "icloud").foregroundColor(.green)
 ///         }
 ///     }
 ///
-@available(iOS 14.0, macCatalyst 14.0, OSX 11, tvOS 14.0, *)
+@available(iOS 14.0, macCatalyst 14.0, OSX 11, tvOS 14.0, watchOS 7, *)
 public class SyncMonitor: ObservableObject {
     /// A singleton to use
     public static let shared = SyncMonitor()
@@ -421,7 +421,13 @@ public class SyncMonitor: ObservableObject {
         // allowing syncing over cellular connections), NSPersistentCloudKitContainer won't try to sync.
         // If that assumption is incorrect, we'll need to update the logic in this class.
         monitor.pathUpdateHandler = { path in
-            DispatchQueue.main.async { self.networkAvailable = (path.status == .satisfied) }
+            DispatchQueue.main.async {
+                #if os(watchOS)
+                self.networkAvailable = (path.availableInterfaces.count > 0)
+                #else
+                self.networkAvailable = (path.status == .satisfied)
+                #endif
+            }
         }
         monitor.start(queue: monitorQueue)
 


### PR DESCRIPTION
Hey! This package is awesome! You're amazing.

Easily displaying the status of CloudKit sync has always been a pain for me, this package made it really easy, thanks.

My app has a watchOS 7 companion app, which I wanted to show sync status on as well.

I noticed that it wasn't properly supported.

This was pretty easy, just had to set the `available`s to include watchOS.

However a trickier part was with the `NWPathMonitor`, which is always unsatisfied on watchOS for technical reasons.

My solution was to just check for available interfaces, which seems to be working ok in my testing!

Let me know if you have any suggestions, happy to give back for your efforts :)

Regards,
Jordi