### PR TITLE
Fix example of different states in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ You could, for example, display details about the user's sync status includng wh
         return dateFormatter
     }()
 
-    print("Setup state: \(stateText(for: SyncMonitor.shared.importState))")
+    print("Setup state: \(stateText(for: SyncMonitor.shared.setupState))")
     print("Import state: \(stateText(for: SyncMonitor.shared.importState))")
-    print("Export state: \(stateText(for: SyncMonitor.shared.importState))")
+    print("Export state: \(stateText(for: SyncMonitor.shared.exportState))")
     
     /// Returns a user-displayable text description of the sync state
     func stateText(for state: SyncMonitor.SyncState) -> String {


### PR DESCRIPTION
Noticed a small error in one of the examples in the README, this is just a simple fix of that.