### PR TITLE
Fix compile error with Xcode Version 13.0 beta (13A5154h)

### DIFF
--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -9,6 +9,7 @@ import Combine
 import CoreData
 import Network
 import SwiftUI
+import CloudKit
 
 /// An object, usually used as a singleton, that provides, and publishes, the current state of `NSPersistentCloudKitContainer`'s sync
 ///


### PR DESCRIPTION
This change is backwards compatible with at least Xcode Version 12.5 (12E262). Not tested any further back.