### PR TITLE
Added watchOS to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     // platforms is set so you can include this package in projects that target iOS 13/macOS 10.15/tvOS 13 without
     // getting errors, but the code in it is marked avaliable only for macOS 11 and iOS 14.
     // It compiles and the tests pass on tvOS 14, but I haven't used it in a tvOS app.
-    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v7), .tvOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
I have seen that the code was already adapted for watchOS 7 and later some time ago. Unfortunately, the platform was not added to the Packages.swift file back then. Therefore I did this so that the package can be used on watchOS as well.