### PR TITLE
fix: bump minimum ios version due to localization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,7 +9,7 @@ let package = Package(
     // platforms is set so you can include this package in projects that target iOS 13/macOS 10.15/tvOS 13 without
     // getting errors, but the code in it is marked avaliable only for macOS 11 and iOS 14.
     // It compiles and the tests pass on tvOS 14, but I haven't used it in a tvOS app.
-    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v7), .tvOS(.v13)],
+    platforms: [.macOS(.v12), .iOS(.v15), .watchOS(.v8), .tvOS(.v15), .macCatalyst(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This SwiftUI view will display a red error image at the top of the screen if the
 ```swift
 import CloudKitSyncMonitor
 struct SyncStatusView: View {
-    @available(iOS 14.0, *)
+    @available(iOS 15.0, *)
     @ObservedObject var syncMonitor = SyncMonitor.shared
 
     var body: some View {
         // Show sync status if there's a sync error 
-         if #available(iOS 14.0, *), syncMonitor.syncStateSummary.isBroken {
+         if #available(iOS 15.0, *), syncMonitor.syncStateSummary.isBroken {
              Image(systemName: syncMonitor.syncStateSummary.symbolName)
                  .foregroundColor(syncMonitor.syncStateSummary.symbolColor)
          }
@@ -30,12 +30,12 @@ removed):
 ```swift
 import CloudKitSyncMonitor
 struct SyncStatusView: View {
-    @available(iOS 14.0, *)
+    @available(iOS 15.0, *)
     @ObservedObject var syncMonitor = SyncMonitor.shared
 
     var body: some View {
         // Show sync status 
-        if #available(iOS 14.0, *) {
+        if #available(iOS 15.0, *) {
             Image(systemName: syncMonitor.syncStateSummary.symbolName)
                 .foregroundColor(syncMonitor.syncStateSummary.symbolColor)
         }
@@ -46,7 +46,7 @@ struct SyncStatusView: View {
 You could change the if clause to this to display an icon only when a sync is in progress or there's an error:
 
 ```swift
-if #available(iOS 14.0, *),
+if #available(iOS 15.0, *),
     (syncMonitor.syncStateSummary.isBroken || syncMonitor.syncStateSummary.inProgress) {
     Image(systemName: syncMonitor.syncStateSummary.symbolName)
         .foregroundColor(syncMonitor.syncStateSummary.symbolColor)
@@ -56,7 +56,7 @@ if #available(iOS 14.0, *),
 Or check for specific states:
 
 ```swift
-if #available(iOS 14.0, *), case .accountNotAvailable = syncMonitor.syncStateSummary {
+if #available(iOS 15.0, *), case .accountNotAvailable = syncMonitor.syncStateSummary {
     Text("Hey, log into your iCloud account if you want to sync")
 }
 ```

--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -91,7 +91,7 @@ import CloudKit
 ///         }
 ///     }
 ///
-@available(iOS 14.0, macCatalyst 14.0, OSX 12, tvOS 14.0, watchOS 7, *)
+@available(iOS 15.0, macCatalyst 14.0, OSX 12, tvOS 15.0, watchOS 8, *)
 public class SyncMonitor: ObservableObject {
     /// A singleton to use
     public static let shared = SyncMonitor()

--- a/Tests/CloudKitSyncMonitorTests/SyncMonitorTests.swift
+++ b/Tests/CloudKitSyncMonitorTests/SyncMonitorTests.swift
@@ -11,7 +11,7 @@ import XCTest
 import CoreData
 @testable import CloudKitSyncMonitor
 
-@available(iOS 14.0, macCatalyst 14.0, OSX 11, tvOS 14.0, *)
+@available(iOS 15.0, macCatalyst 14.0, OSX 11, tvOS 15.0, *)
 final class SyncMonitorTests: XCTestCase {
     func testCanDetectImportError() {
         // Given an active network connection


### PR DESCRIPTION
As localization was recently added [here](https://github.com/ggruen/CloudKitSyncMonitor/blob/32457c7aa394eb8254d24ae387445befc2eb36e8/Sources/CloudKitSyncMonitor/SyncMonitor.swift#L186-L200), this requires a bump in the minimum OS version.

Refer to https://developer.apple.com/documentation/swift/string/init(localized:table:bundle:locale:comment:) for more details.