### PR TITLE
Fix min Mac Catalyst version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,7 @@ import PackageDescription
 let package = Package(
     name: "CloudKitSyncMonitor",
     defaultLocalization: "en",
-    // platforms is set so you can include this package in projects that target iOS 13/macOS 10.15/tvOS 13 without
-    // getting errors, but the code in it is marked avaliable only for macOS 11 and iOS 14.
-    // It compiles and the tests pass on tvOS 14, but I haven't used it in a tvOS app.
-    platforms: [.macOS(.v12), .iOS(.v15), .watchOS(.v8), .tvOS(.v15), .macCatalyst(.v14)],
+    platforms: [.macOS(.v12), .iOS(.v15), .watchOS(.v8), .tvOS(.v15), .macCatalyst(.v15)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Changed the min Catalyst version to 15 instead of 14, so it matches the min version in the code.