### PR TITLE
add @MainActor to SyncMonitor

### DIFF
--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -92,6 +92,7 @@ import CloudKit
 ///     }
 ///
 @available(iOS 15.0, macCatalyst 15.0, OSX 12, tvOS 15.0, watchOS 8, *)
+@MainActor
 public class SyncMonitor: ObservableObject {
     /// A singleton to use
     public static let shared = SyncMonitor()


### PR DESCRIPTION
fix `Class property 'shared' is not concurrency-safe because non-'Sendable' type 'SyncMonitor' may have shared mutable state` error in xcode 16 beta 3 and swift 6.
![Screenshot 2024-07-12 at 09 46 30](https://github.com/user-attachments/assets/bb0243ad-02aa-4412-89ea-cd962c60bd08)

