### PR TITLE
prevent crash on swiftui preview

### DIFF
--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -494,6 +494,13 @@ public class SyncMonitor: ObservableObject {
     /// When SyncMonitor is listening to notifications (which it does unless you tell it not to when initializing), this method is called each time CKContainer
     /// fires off a `.CKAccountChanged` notification.
     private func updateiCloudAccountStatus() {
+        #if DEBUG
+        let isPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+        guard !isPreview else {
+            return
+        }
+        #endif
+            
         CKContainer.default().accountStatus { (accountStatus, error) in
             DispatchQueue.main.async {
                 if let e = error {

--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -496,7 +496,7 @@ public class SyncMonitor: ObservableObject {
     private func updateiCloudAccountStatus() {
         #if DEBUG
         let isPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
-        guard !isPreview else {
+        if isPreview {
             return
         }
         #endif


### PR DESCRIPTION
`CKContainer.default().accountStatus` causes a crash in SwiftUI preview. To fix this, I added a conditional check to skip calling this function in preview mode.