### PR TITLE
Improve Boolean property names, conform SyncState to Equatable, & correct example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This SwiftUI view will display a red error image at the top of the screen if the
 import CloudKitSyncMonitor
 struct SyncStatusView: View {
     @available(iOS 15.0, *)
-    @ObservedObject var syncMonitor = SyncMonitor.shared
+    @StateObject var syncMonitor = SyncMonitor.shared
 
     var body: some View {
         // Show sync status if there's a sync error 
@@ -31,7 +31,7 @@ removed):
 import CloudKitSyncMonitor
 struct SyncStatusView: View {
     @available(iOS 15.0, *)
-    @ObservedObject var syncMonitor = SyncMonitor.shared
+    @StateObject var syncMonitor = SyncMonitor.shared
 
     var body: some View {
         // Show sync status 
@@ -81,14 +81,14 @@ Setup, Import, and Export.
 `SyncMonitor` stores the current state of each of these types of events in `setupState`, `importState`, and `exportState` respectively,
 and provides convenience methods to extract commonly-needed information from these.
 
-You can tell if there's a sync problem by checking the `syncError` and `notSyncing` properties, and get error details from the `setupError`,
+You can tell if there's a sync problem by checking the `hasSyncError` and `isNotSyncing` properties, and get error details from the `setupError`,
 `importError`, and `exportError` computed properties.
 
 This code will detect if there's a sync issue that your user, or your app, needs to do something about:
 
 ```swift
 // If true, either setupError, importError or exportError will contain an error
-if SyncMonitor.shared.syncError {
+if SyncMonitor.shared.hasSyncError {
     if let e = SyncMonitor.shared.setupError {
         print("Unable to set up iCloud sync, changes won't be saved! \(e.localizedDescription)")
     }
@@ -98,15 +98,15 @@ if SyncMonitor.shared.syncError {
     if let e = SyncMonitor.shared.exportError {
         print("Export is broken - your changes aren't being saved! \(e.localizedDescription)")
     }
-} else if SyncMonitor.shared.notSyncing {
+} else if SyncMonitor.shared.isNotSyncing {
     print("Sync should be working, but isn't. Look for a badge on Settings or other possible issues.")
 }
 ```
 
- `notSyncing` is a special property that tells you when `SyncMonitor` has noticed that `NSPersistentCloudKitContainer` reported that
+ `isNotSyncing` is a special property that tells you when `SyncMonitor` has noticed that `NSPersistentCloudKitContainer` reported that
 its "setup" event completed successfully, but that no "import" event was started, and no errors were reported. This can happen, for example,
 if the OS has presented a "please re-enter your password" notification/popup (in which case, CloudKit consider's the user's account
-"available", but NSPersistentCloudKitContainer won't actually be able to sync). `notSyncing`, like `isBroken`, take things like network
+"available", but NSPersistentCloudKitContainer won't actually be able to sync). `isNotSyncing`, like `isBroken`, take things like network
 availability and the user's iCloud login status into account.
 
 Detecting error conditions is important because the usual "fix" for CloudKit not syncing is to delete the local database. This

--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -1,6 +1,6 @@
 //
 //  SyncMonitor.swift
-//  
+//
 //
 //  Created by Grant Grueninger on 9/23/20.
 //
@@ -20,7 +20,7 @@ import CloudKit
 /// Here are the basics:
 ///
 ///     // If true, either setupError, importError or exportError will contain an error
-///     if SyncMonitor.shared.syncError {
+///     if SyncMonitor.shared.hasSyncError {
 ///         if let e = SyncMonitor.shared.setupError {
 ///             print("Unable to set up iCloud sync, changes won't be saved! \(e.localizedDescription)")
 ///         }
@@ -30,11 +30,11 @@ import CloudKit
 ///         if let e = SyncMonitor.shared.exportError {
 ///             print("Export is broken - your changes aren't being saved! \(e.localizedDescription)")
 ///         }
-///     } else if SyncMonitor.shared.notSyncing {
+///     } else if SyncMonitor.shared.isNotSyncing {
 ///         print("Sync should be working, but isn't. Look for a badge on Settings or other possible issues.")
 ///     }
 ///
-/// `syncError` and `notSyncing`, together, tell you if there's a problem that `NSPersistentCloudKitContainer` has announced or not announced
+/// `hasSyncError` and `isNotSyncing`, together, tell you if there's a problem that `NSPersistentCloudKitContainer` has announced or not announced
 /// (respectively).
 /// The `setupError`, `importError`, and `exportError` properties can give you the reported error. Digging deeper, `setupState`, `importState`,
 /// and `exportState` give you the state of each type of `NSPersistentCloudKitContainer` event in a nice little `SyncState` enum with associated
@@ -45,7 +45,7 @@ import CloudKit
 ///
 /// First, observe the shared syncmonitor instance so your view will update if the state changes:
 ///
-///     @ObservedObject var syncMonitor: SyncMonitor = SyncMonitor.shared
+///     @StateObject var syncMonitor: SyncMonitor = SyncMonitor.shared
 ///
 /// Show a sync status icon:
 ///
@@ -84,7 +84,7 @@ import CloudKit
 ///                     }
 ///                 }
 ///             }
-///         } else if syncMonitor.notSyncing {
+///         } else if syncMonitor.isNotSyncing {
 ///             Image(systemName: "xmark.icloud")
 ///         } else {
 ///             Image(systemName: "icloud").foregroundColor(.green)
@@ -96,9 +96,9 @@ import CloudKit
 public class SyncMonitor: ObservableObject {
     /// A singleton to use
     public static let shared = SyncMonitor()
-
+    
     // MARK: - Summary properties -
-
+    
     /// Returns an overview of the state of sync, which you could use to display a summary icon
     ///
     /// The general sync state is detmined as follows:
@@ -107,7 +107,7 @@ public class SyncMonitor: ObservableObject {
     ///     state summary is`.accountNotAvailable`.
     /// - Otherwise, if `NSPersistentCloudKitContainer` reported an error for any event type the last time that event type ran, the state summary is
     ///     `.error`.
-    /// - Otherwise, if `notSyncing` is true, the state is `.notSyncing`.
+    /// - Otherwise, if `isNotSyncing` is true, the state is `.isNotSyncing`.
     /// - Otherwise, if all event types are `.notStarted`, the state is `.notStarted`.
     /// - Otherwise, if any event type is `.inProgress`, the state is `.inProgress`.
     /// - Otherwise, if all event types are `.successful`, the state is `.succeeded`.
@@ -115,7 +115,7 @@ public class SyncMonitor: ObservableObject {
     ///
     /// Here's how you might use this in a SwiftUI view:
     ///
-    ///     @ObservedObject var syncMonitor: SyncMonitor = SyncMonitor.shared
+    ///     @StateObject var syncMonitor: SyncMonitor = SyncMonitor.shared
     ///
     ///     Image(systemName: syncMonitor.syncStateSummary.symbolName)
     ///         .foregroundColor(syncMonitor.syncStateSummary.symbolColor)
@@ -138,26 +138,26 @@ public class SyncMonitor: ObservableObject {
     public var syncStateSummary: SyncSummaryStatus {
         if networkAvailable == false { return .noNetwork }
         guard case .available = iCloudAccountStatus else { return .accountNotAvailable }
-        if syncError { return .error }
-        if notSyncing { return .notSyncing }
+        if hasSyncError { return .error }
+        if isNotSyncing { return .notSyncing }
         if case .notStarted = importState, case .notStarted = exportState, case .notStarted = setupState {
             return .notStarted
         }
-
+        
         if case .inProgress = setupState { return .inProgress }
         if case .inProgress = importState { return .inProgress }
         if case .inProgress = exportState { return .inProgress }
-
+        
         if case .succeeded = importState, case .succeeded = exportState {
             return .succeeded
         }
         return .unknown
     }
-
+    
     /// Possible values for the summary of the state of iCloud sync
     public enum SyncSummaryStatus {
         case noNetwork, accountNotAvailable, error, notSyncing, notStarted, inProgress, succeeded, unknown
-
+        
         /// A symbol you could use to display the status
         public var symbolName: String {
             switch self {
@@ -201,7 +201,7 @@ public class SyncMonitor: ObservableObject {
                 return String(localized: "Error")
             }
         }
-
+        
         /// A color you could use for the symbol
         public var symbolColor: Color {
             switch self {
@@ -223,7 +223,7 @@ public class SyncMonitor: ObservableObject {
                 return .red
             }
         }
-
+        
         /// Returns true if the state indicates that sync is broken
         public var isBroken: Bool {
             switch self {
@@ -245,7 +245,7 @@ public class SyncMonitor: ObservableObject {
                 return true
             }
         }
-
+        
         /// Convenience accessor that returns true if a sync is in progress
         ///
         /// This lets you do things like `if SyncMonitor.shared.broken || SyncMonitor.shared.inProgress { ... }`,
@@ -257,14 +257,14 @@ public class SyncMonitor: ObservableObject {
             return false
         }
     }
-
+    
     /// Returns true if `NSPersistentCloudKitContainer` has reported an error.
     ///
     /// This is a convenience property that returns true if `setupError`, `importError` or `exportError` is not nil.
-    /// If `syncError` is true, then either `setupError`, `importError` or `exportError` (or any combination of them)) will contain an error object.
+    /// If `hasSyncError` is true, then either `setupError`, `importError` or `exportError` (or any combination of them)) will contain an error object.
     ///
     ///     // If true, either setupError, importError or exportError will contain an error
-    ///     if SyncMonitor.shared.syncError {
+    ///     if SyncMonitor.shared.hasSyncError {
     ///         if let e = SyncMonitor.shared.setupError {
     ///             print("Unable to set up iCloud sync, changes won't be saved! \(e.localizedDescription)")
     ///         }
@@ -276,49 +276,49 @@ public class SyncMonitor: ObservableObject {
     ///         }
     ///     }
     ///
-    /// `syncError` being `true` means that `NSPersistentCloudKitContainer` sent a notification that included an error.
-    public var syncError: Bool {
+    /// `hasSyncError` being `true` means that `NSPersistentCloudKitContainer` sent a notification that included an error.
+    public var hasSyncError: Bool {
         return setupError != nil || importError != nil || exportError != nil
     }
-
+    
     /// Returns `true` if there's no reason that we know of why sync shouldn't be working
     ///
     /// That is, the user's iCloud account status is "available", the network is available, there are no recorded sync errors, and setup is complete and succeeded.
     public var shouldBeSyncing: Bool {
-        if case .available = iCloudAccountStatus, self.networkAvailable == true, !syncError,
+        if case .available = iCloudAccountStatus, self.networkAvailable == true, !hasSyncError,
            case .succeeded = setupState {
             return true
         }
         return false
     }
-
+    
     /// Detects a condition in which CloudKit _should_ be syncing, but isn't.
     ///
-    /// `notSyncing` is true if `shouldBeSyncing` is true (see `shouldBeSyncing`) but `importState` is still `.notStarted`.
+    /// `isNotSyncing` is true if `shouldBeSyncing` is true (see `shouldBeSyncing`) but `importState` is still `.notStarted`.
     ///
-    /// The first thing `NSPersistentCloudKitContainer`does when the app starts is to set up, then run an import. So, `notSyncing` should be true for
+    /// The first thing `NSPersistentCloudKitContainer`does when the app starts is to set up, then run an import. So, `isNotSyncing` should be true for
     /// a very very short period of time (e.g. less than a second) for the time between when setup completes and the import starts. As such, it's suitable for
-    /// displaying an error graphic to the user, e.g. `Image(systemName: "xmark.icloud")` if `notSyncing` is `true`, but not necessarily for
-    /// programmatic action (unless notSyncing stays true for more than a few seconds).
+    /// displaying an error graphic to the user, e.g. `Image(systemName: "xmark.icloud")` if `isNotSyncing` is `true`, but not necessarily for
+    /// programmatic action (unless isNotSyncing stays true for more than a few seconds).
     ///
-    ///     if SyncMonitor.shared.syncError {
+    ///     if SyncMonitor.shared.hasSyncError {
     ///         // Act on error
-    ///     } else if SyncMonitor.shared.notSyncing {
+    ///     } else if SyncMonitor.shared.isNotSyncing {
     ///         print("Sync should be working, but isn't. Look for a badge on Settings or other possible issues.")
     ///     }
     ///
-    /// I would argue that `notSyncing` being `true` for a longer period of time indicates a bug in `NSPersistentCloudKitContainer`. E.g. the case
+    /// I would argue that `isNotSyncing` being `true` for a longer period of time indicates a bug in `NSPersistentCloudKitContainer`. E.g. the case
     /// that made me write this computed property is that if Settings on iOS wants the user to log in again, CloudKit will report a "partial error" when setting up,
-    /// but ultimately send a notifiation stating that setup was successful; however, CloudKit will then just not sync, providing no errors. `notSyncing` detects
-    /// this condition, and those like it. If you see `notSyncing` being triggered, I'd recommend isolating the issue (e.g. the one above) and filing a FB about it
+    /// but ultimately send a notifiation stating that setup was successful; however, CloudKit will then just not sync, providing no errors. `isNotSyncing` detects
+    /// this condition, and those like it. If you see `isNotSyncing` being triggered, I'd recommend isolating the issue (e.g. the one above) and filing a FB about it
     /// to Apple.
-    public var notSyncing: Bool {
+    public var isNotSyncing: Bool {
         if case .notStarted = importState, shouldBeSyncing {
             return true
         }
         return false
     }
-
+    
     /// If not `nil`, there is a real problem encountered when CloudKit was trying to set itself up
     ///
     /// This means `NSPersistentCloudKitContainer` probably won't try to do imports or exports, which means that data won't be synced. However, it's
@@ -332,7 +332,7 @@ public class SyncMonitor: ObservableObject {
         }
         return nil
     }
-
+    
     /// If not `nil`, there is a problem with CloudKit's import.
     public var importError: Error? {
         if networkAvailable == true, let error = importState.error {
@@ -340,7 +340,7 @@ public class SyncMonitor: ObservableObject {
         }
         return nil
     }
-
+    
     /// If not `nil`, there is a real problem with CloudKit's export
     ///
     ///     if let error = SyncMonitor.shared.exportError {
@@ -359,52 +359,52 @@ public class SyncMonitor: ObservableObject {
         }
         return nil
     }
-
+    
     // MARK: - Specific Status Properties -
-
+    
     /// The state of `NSPersistentCloudKitContainer`'s "setup" event
     @Published public private(set) var setupState: SyncState = .notStarted
-
+    
     /// The state of `NSPersistentCloudKitContainer`'s "import" event
     @Published public private(set) var importState: SyncState = .notStarted
-
+    
     /// The state of `NSPersistentCloudKitContainer`'s "export" event
     @Published public private(set) var exportState: SyncState = .notStarted
-
+    
     /// Is the network available?
     ///
-    /// This is true if the network is available in any capacity (Wi-Fi, Ethernet, cellular, carrier pidgeon, etc) - we just care if we can reach iCloud. 
+    /// This is true if the network is available in any capacity (Wi-Fi, Ethernet, cellular, carrier pidgeon, etc) - we just care if we can reach iCloud.
     @Published public private(set) var networkAvailable: Bool? = nil
-
+    
     @Published public private(set) var loggedIntoIcloud: Bool? = nil
-
+    
     /// The current status of the user's iCloud account - updated automatically if they change it
     @Published public private(set) var iCloudAccountStatus: CKAccountStatus?
-
+    
     /// If an error was encountered when retrieving the user's account status, this will be non-nil
     public private(set) var iCloudAccountStatusUpdateError: Error?
-
+    
     // MARK: - Diagnosis properties -
-
+    
     /// Contains the last Error encountered.
     ///
-    /// This can be helpful in diagnosing "notSyncing" issues or other "partial error"s from which CloudKit thinks it recovered, but didn't really.
+    /// This can be helpful in diagnosing "isNotSyncing" issues or other "partial error"s from which CloudKit thinks it recovered, but didn't really.
     public private(set) var lastError: Error?
-
+    
     // MARK: - Listeners -
-
+    
     /// Where we store Combine cancellables for publishers we're listening to, e.g. NSPersistentCloudKitContainer's notifications.
     private var disposables = Set<AnyCancellable>()
-
+    
     /// Network path monitor that's used to track whether we can reach the network at all
     //    fileprivate let monitor: NetworkMonitor = NWPathMonitor()
     private let monitor = NWPathMonitor()
-
+    
     /// The queue on which we'll run our network monitor
     private let monitorQueue = DispatchQueue(label: "NetworkMonitor")
-
+    
     // MARK: - Initializers -
-
+    
     /// Creates a new sync monitor and sets up listeners to sync and network changes
     public init(setupState: SyncState = .notStarted, importState: SyncState = .notStarted,
                 exportState: SyncState = .notStarted, networkAvailable: Bool? = nil,
@@ -419,9 +419,9 @@ public class SyncMonitor: ObservableObject {
         if let e = lastErrorText {
             self.lastError = NSError(domain: e, code: 0, userInfo: nil)
         }
-
+        
         guard listen else { return }
-
+        
         // Monitor NSPersistentCloudKitContainer sync events
         if #available(iOS 14.0, macCatalyst 14.0, *) { // Crashes on 13.7 w/o this, even though we have @available
             NotificationCenter.default.publisher(for: NSPersistentCloudKitContainer.eventChangedNotification)
@@ -429,14 +429,14 @@ public class SyncMonitor: ObservableObject {
                     if let cloudEvent = notification.userInfo?[NSPersistentCloudKitContainer.eventNotificationUserInfoKey]
                         as? NSPersistentCloudKitContainer.Event {
                         let event = SyncEvent(from: cloudEvent) // To make testing possible
-                        // Properties need to be set on the main thread for SwiftUI, so we'll do that here
-                        // instead of maing setProperties run async code, which is inconvenient for testing.
+                                                                // Properties need to be set on the main thread for SwiftUI, so we'll do that here
+                                                                // instead of maing setProperties run async code, which is inconvenient for testing.
                         DispatchQueue.main.async { self.setProperties(from: event) }
                     }
                 })
                 .store(in: &disposables)
         }
-
+        
         // Update the network status when the OS reports a change. Note that we ignore whether the connection is
         // expensive or not - we just care whether iCloud is _able_ to sync. If there's no network,
         // NSPersistentCloudKitContainer will try to sync but report an error. We consider that a real error unless
@@ -446,15 +446,15 @@ public class SyncMonitor: ObservableObject {
         // If that assumption is incorrect, we'll need to update the logic in this class.
         monitor.pathUpdateHandler = { path in
             DispatchQueue.main.async {
-                #if os(watchOS)
+#if os(watchOS)
                 self.networkAvailable = (path.availableInterfaces.count > 0)
-                #else
+#else
                 self.networkAvailable = (path.status == .satisfied)
-                #endif
+#endif
             }
         }
         monitor.start(queue: monitorQueue)
-
+        
         // Monitor changes to the iCloud account (e.g. login/logout)
         self.updateiCloudAccountStatus()
         NotificationCenter.default.publisher(for: .CKAccountChanged)
@@ -464,7 +464,7 @@ public class SyncMonitor: ObservableObject {
             })
             .store(in: &disposables)
     }
-
+    
     /// Convenience initializer that creates a SyncMonitor with preset state values for testing or previews
     ///
     ///     let syncMonitor = SyncMonitor(importSuccessful: false, errorText: "Cloud distrupted by weather net")
@@ -477,30 +477,30 @@ public class SyncMonitor: ObservableObject {
         let startDate = Date(timeIntervalSinceNow: -15) // a 15 second sync. :o
         let endDate = Date()
         self.setupState = setupSuccessful
-            ? SyncState.succeeded(started: startDate, ended: endDate)
-            : .failed(started: startDate, ended: endDate, error: error)
+        ? SyncState.succeeded(started: startDate, ended: endDate)
+        : .failed(started: startDate, ended: endDate, error: error)
         self.importState = importSuccessful
-            ? .succeeded(started: startDate, ended: endDate)
-            : .failed(started: startDate, ended: endDate, error: error)
+        ? .succeeded(started: startDate, ended: endDate)
+        : .failed(started: startDate, ended: endDate, error: error)
         self.exportState = exportSuccessful
-            ? .succeeded(started: startDate, ended: endDate)
-            : .failed(started: startDate, ended: endDate, error: error)
+        ? .succeeded(started: startDate, ended: endDate)
+        : .failed(started: startDate, ended: endDate, error: error)
         self.networkAvailable = networkAvailable
         self.iCloudAccountStatus = iCloudAccountStatus
     }
-
+    
     /// Checks the current status of the user's iCloud account and updates our iCloudAccountStatus property
     ///
     /// When SyncMonitor is listening to notifications (which it does unless you tell it not to when initializing), this method is called each time CKContainer
     /// fires off a `.CKAccountChanged` notification.
     private func updateiCloudAccountStatus() {
-        #if DEBUG
+#if DEBUG
         let isPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
         if isPreview {
             return
         }
-        #endif
-            
+#endif
+        
         CKContainer.default().accountStatus { (accountStatus, error) in
             DispatchQueue.main.async {
                 if let e = error {
@@ -511,9 +511,9 @@ public class SyncMonitor: ObservableObject {
             }
         }
     }
-
+    
     // MARK: - Processing NSPersistentCloudKitContainer events -
-
+    
     /// Set the appropriate State property (importState, exportState, setupState) based on the provided event
     internal func setProperties(from event: SyncEvent) {
         // First, set the SyncState for the event
@@ -529,7 +529,7 @@ public class SyncMonitor: ObservableObject {
                 state = .failed(started: startDate, ended: endDate, error: event.error)
             }
         }
-
+        
         switch event.type {
         case .setup:
             setupState = state
@@ -540,12 +540,12 @@ public class SyncMonitor: ObservableObject {
         @unknown default:
             assertionFailure("NSPersistentCloudKitContainer added a new event type.")
         }
-
+        
         if event.error != nil {
             lastError = event.error
         }
     }
-
+    
     /// A sync event containing the values from NSPersistentCloudKitContainer.Event that we track
     internal struct SyncEvent {
         var type: NSPersistentCloudKitContainer.EventType
@@ -553,7 +553,7 @@ public class SyncMonitor: ObservableObject {
         var endDate: Date?
         var succeeded: Bool
         var error: Error?
-
+        
         /// Creates a SyncEvent from explicitly provided values (for testing)
         init(type: NSPersistentCloudKitContainer.EventType, startDate: Date?, endDate: Date?, succeeded: Bool,
              error: Error?) {
@@ -563,7 +563,7 @@ public class SyncMonitor: ObservableObject {
             self.succeeded = succeeded
             self.error = error
         }
-
+        
         /// Creates a SyncEvent from an NSPersistentCloudKitContainer Event
         init(from cloudKitEvent: NSPersistentCloudKitContainer.Event) {
             self.type = cloudKitEvent.type
@@ -573,23 +573,23 @@ public class SyncMonitor: ObservableObject {
             self.error = cloudKitEvent.error
         }
     }
-
+    
     // MARK: - Defining state -
-
+    
     /// The state of a CloudKit import, export, or setup event as reported by an `NSPersistentCloudKitContainer` notification
-    public enum SyncState {
+    public enum SyncState: Equatable {
         /// No event has been reported
         case notStarted
-
+        
         /// A notification with a start date was received, but it had no end date.
         case inProgress(started: Date)
-
+        
         /// The last sync of this type finished and succeeded (`succeeded` was `true` in the notification from `NSPersistentCloudKitContainer`).
         case succeeded(started: Date, ended: Date)
-
+        
         /// The last sync of this type finished but failed (`succeeded` was `false` in the notification from `NSPersistentCloudKitContainer`).
         case failed(started: Date, ended: Date, error: Error?)
-
+        
         /// Convenience property that returns true if the last sync of this type succeeded
         ///
         /// `succeeded` is true if the sync finished and reported true for its "succeeded" property.
@@ -598,13 +598,13 @@ public class SyncMonitor: ObservableObject {
             if case .succeeded = self { return true }
             return false
         }
-
+        
         /// Convenience property that returns true if the last sync of this type failed
         var failed: Bool {
             if case .failed = self { return true }
             return false
         }
-
+        
         /// Convenience property that returns the error returned if the event failed
         ///
         /// This is the main property you'll want to use to detect an error, as it will be `nil` if the sync is incomplete or succeeded, and will contain
@@ -617,10 +617,43 @@ public class SyncMonitor: ObservableObject {
         /// Note that this property will report all errors, including those caused by normal things like being offline.
         /// See also `SyncMonitor.importError` and `SyncMonitor.exportError` for more intelligent error reporting.
         var error: Error? {
-            if case let .failed(_,_,error) = self, let e = error {
+            if case .failed(_, _, let error) = self, let e = error {
                 return e
             }
             return nil
+        }
+        
+        public static func == (lhs: SyncState, rhs: SyncState) -> Bool {
+            switch (lhs, rhs) {
+            case (.notStarted, .notStarted):
+                return true
+                
+            case (.inProgress(let lhsStarted), .inProgress(let rhsStarted)):
+                return lhsStarted == rhsStarted
+                
+            case (.succeeded(let lhsStarted, let lhsEnded), .succeeded(let rhsStarted, let rhsEnded)):
+                return lhsStarted == rhsStarted && lhsEnded == rhsEnded
+                
+            case (.failed(let lhsStarted, let lhsEnded, let lhsError), .failed(let rhsStarted, let rhsEnded, let rhsError)):
+                
+                let datesEqual = lhsStarted == rhsStarted && lhsEnded == rhsEnded
+                
+                // Since Error doesn't conform to Equatable, we'll compare their localized descriptions
+                let errorsEqual: Bool
+                switch (lhsError, rhsError) {
+                case (nil, nil):
+                    errorsEqual = true
+                case (let lhsErr?, let rhsErr?):
+                    errorsEqual = lhsErr.localizedDescription == rhsErr.localizedDescription
+                default:
+                    errorsEqual = false
+                }
+                
+                return datesEqual && errorsEqual
+                
+            default:
+                return false
+            }
         }
     }
 }

--- a/Sources/CloudKitSyncMonitor/SyncMonitor.swift
+++ b/Sources/CloudKitSyncMonitor/SyncMonitor.swift
@@ -257,6 +257,9 @@ public class SyncMonitor: ObservableObject {
             return false
         }
     }
+  
+    @available(*, deprecated, renamed: "hasSyncError")
+    public var syncError: Bool { hasSyncError }
     
     /// Returns true if `NSPersistentCloudKitContainer` has reported an error.
     ///
@@ -291,6 +294,9 @@ public class SyncMonitor: ObservableObject {
         }
         return false
     }
+  
+    @available(*, deprecated, renamed: "isNotSyncing")
+    public var notSyncing: Bool { isNotSyncing }
     
     /// Detects a condition in which CloudKit _should_ be syncing, but isn't.
     ///


### PR DESCRIPTION
Change “syncError” to “hasSyncError” and “notSyncing” to “isNotSyncing” to improve clarity and align with Swift naming conventions. Correct property wrappers in example code. Add Equatable conformance to SyncState for compatibility with onChange() modifier.